### PR TITLE
Fix: fields_for syntax to avoid unpermitted parameters

### DIFF
--- a/app/views/nostalgic/_collection_select.html.erb
+++ b/app/views/nostalgic/_collection_select.html.erb
@@ -14,7 +14,7 @@
   </thead>
   <tbody style="display: none;">
     <% f.object.public_send(attr.to_s.pluralize).each_with_index do |nostalgic_attr, i| %>
-      <%= f.fields_for "#{attr.to_s.pluralize}_attributes][#{i}]", nostalgic_attr do |f| %>
+      <%= f.fields_for attr.to_s.pluralize, nostalgic_attr, child_index: i do |f| %>
         <tr>
           <td>
             <%= f.hidden_field :id %>

--- a/app/views/nostalgic/_text_field.html.erb
+++ b/app/views/nostalgic/_text_field.html.erb
@@ -14,7 +14,7 @@
   </thead>
   <tbody style="display: none;">
     <% f.object.public_send(attr.to_s.pluralize).each_with_index do |nostalgic_attr, i| %>
-      <%= f.fields_for "#{attr.to_s.pluralize}_attributes][#{i}]", nostalgic_attr do |f| %>
+      <%= f.fields_for attr.to_s.pluralize, nostalgic_attr, child_index: i do |f| %>
         <tr>
           <td>
             <%= f.hidden_field :id %>


### PR DESCRIPTION
In a Rails 7.2 application using the nostalgic gem, form submissions were generating broken parameter keys, which resulted in errors such as:

ActionController::UnpermittedParameters
(found unpermitted parameters: :][id], :][_destroy])

Example of the broken parameters:
"addresses_attributes" => {
  "0" => { "][id]" => "3", "][_destroy]" => "false" }
}

Fix:
Use Rails’ standard `child_index` option in `fields_for` so that parameters are generated correctly:
```diff
- <%= f.fields_for "#{attr.to_s.pluralize}_attributes][#{i}", nostalgic_attr do |f| %>
+ <%= f.fields_for attr.to_s.pluralize, nostalgic_attr, child_index: i do |f| %>
```
With this change, the generated parameters are now valid:

"addresses_attributes" => {
  "0" => { "id" => "3", "_destroy" => "false" }
}

I have verified this fix in my local Rails 7.2 application: form submission and update now work as expected.